### PR TITLE
Vector support

### DIFF
--- a/internal/driver/common/vector_types.go
+++ b/internal/driver/common/vector_types.go
@@ -1,0 +1,14 @@
+package common
+
+// VectorFloat64 represents dense VECTOR(FLOAT64) bind values.
+type VectorFloat64 []float64
+
+// VectorFloat32 represents dense VECTOR(FLOAT32) bind values.
+type VectorFloat32 []float32
+
+// VectorInt8 represents dense VECTOR(INT8) bind values.
+type VectorInt8 []int8
+
+// VectorBinary represents a packed BINARY VECTOR payload.
+// Each byte stores 8 dimensions in MSB-first order.
+type VectorBinary []byte

--- a/internal/driver/ttc/bind_value.go
+++ b/internal/driver/ttc/bind_value.go
@@ -8,47 +8,42 @@ import (
 	oracleErrors "github.com/oracle/go-oracledb/v26/oracle/errors"
 )
 
-// bindTransport owns the TTC wire representation for a prepared bind value.
-type bindTransport interface {
-	marshal(context.Context, driverCommon.Marshaller, driverCommon.MessageType, int, bindValue) error
-}
+type bindValueKind uint8
 
-// bindValue stores an encoded bind value together with the transport used to marshal it.
+const (
+	bindValueKindCLR bindValueKind = iota
+	bindValueKindVector
+)
+
+// bindValue keeps the encoded bytes and the TTC representation TTIRXD must use.
 type bindValue struct {
-	transport bindTransport
-	payload   driverCommon.B1Array
-	isNull    bool
+	kind    bindValueKind
+	payload driverCommon.B1Array
 }
-
-var defaultCLRBindTransport bindTransport = clrBindTransport{}
 
 func newCLRBindValue(payload driverCommon.B1Array) bindValue {
 	return bindValue{
-		transport: defaultCLRBindTransport,
-		payload:   payload,
-		isNull:    payload == nil,
+		kind:    bindValueKindCLR,
+		payload: payload,
 	}
 }
 
 func (v bindValue) marshal(ctx context.Context, engine driverCommon.Marshaller, msgCode driverCommon.MessageType, index int) error {
-	transport := v.transport
-	if transport == nil {
-		transport = defaultCLRBindTransport
+	if v.kind == bindValueKindVector {
+		return marshalVectorBind(ctx, engine, msgCode, index, v.payload)
 	}
-	return transport.marshal(ctx, engine, msgCode, index, v)
+	return marshalCLRBind(ctx, engine, msgCode, index, v.payload)
 }
 
-// clrBindTransport marshals binds using the generic CLR encoding path.
-type clrBindTransport struct{}
-
-func (clrBindTransport) marshal(
+// marshalCLRBind marshals ordinary binds using a single CLR value.
+func marshalCLRBind(
 	ctx context.Context,
 	engine driverCommon.Marshaller,
 	msgCode driverCommon.MessageType,
 	index int,
-	bind bindValue,
+	payload driverCommon.B1Array,
 ) error {
-	if bind.isNull || bind.payload == nil {
+	if payload == nil {
 		if err := engine.MarshalUB1(ctx, driverCommon.UB1(0)); err != nil {
 			common.Odl.Error("tTIrxd.MarshalTo: failed to write null length indicator",
 				"error", err, "stage", "null-indicator", "index", index)
@@ -56,7 +51,7 @@ func (clrBindTransport) marshal(
 		}
 		return nil
 	}
-	if err := engine.MarshalCLR(ctx, bind.payload, 0, len(bind.payload)); err != nil {
+	if err := engine.MarshalCLR(ctx, payload, 0, len(payload)); err != nil {
 		common.Odl.Error("tTIrxd.MarshalTo: failed to write CLR",
 			"error", err, "stage", "clr", "index", index)
 		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])

--- a/internal/driver/ttc/bind_value.go
+++ b/internal/driver/ttc/bind_value.go
@@ -1,0 +1,65 @@
+package ttc
+
+import (
+	"context"
+
+	"github.com/oracle/go-oracledb/v26/internal/common"
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+	oracleErrors "github.com/oracle/go-oracledb/v26/oracle/errors"
+)
+
+// bindTransport owns the TTC wire representation for a prepared bind value.
+type bindTransport interface {
+	marshal(context.Context, driverCommon.Marshaller, driverCommon.MessageType, int, bindValue) error
+}
+
+// bindValue stores an encoded bind value together with the transport used to marshal it.
+type bindValue struct {
+	transport bindTransport
+	payload   driverCommon.B1Array
+	isNull    bool
+}
+
+var defaultCLRBindTransport bindTransport = clrBindTransport{}
+
+func newCLRBindValue(payload driverCommon.B1Array) bindValue {
+	return bindValue{
+		transport: defaultCLRBindTransport,
+		payload:   payload,
+		isNull:    payload == nil,
+	}
+}
+
+func (v bindValue) marshal(ctx context.Context, engine driverCommon.Marshaller, msgCode driverCommon.MessageType, index int) error {
+	transport := v.transport
+	if transport == nil {
+		transport = defaultCLRBindTransport
+	}
+	return transport.marshal(ctx, engine, msgCode, index, v)
+}
+
+// clrBindTransport marshals binds using the generic CLR encoding path.
+type clrBindTransport struct{}
+
+func (clrBindTransport) marshal(
+	ctx context.Context,
+	engine driverCommon.Marshaller,
+	msgCode driverCommon.MessageType,
+	index int,
+	bind bindValue,
+) error {
+	if bind.isNull || bind.payload == nil {
+		if err := engine.MarshalUB1(ctx, driverCommon.UB1(0)); err != nil {
+			common.Odl.Error("tTIrxd.MarshalTo: failed to write null length indicator",
+				"error", err, "stage", "null-indicator", "index", index)
+			return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
+		}
+		return nil
+	}
+	if err := engine.MarshalCLR(ctx, bind.payload, 0, len(bind.payload)); err != nil {
+		common.Odl.Error("tTIrxd.MarshalTo: failed to write CLR",
+			"error", err, "stage", "clr", "index", index)
+		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
+	}
+	return nil
+}

--- a/internal/driver/ttc/connection.go
+++ b/internal/driver/ttc/connection.go
@@ -246,6 +246,9 @@ func (c *connection) CheckNamedValue(nv *driver.NamedValue) error {
 // checkNamedValue validates sql.Out destinations and returns shelf-localized
 // Oracle errors for binding problems.
 func checkNamedValue(nv *driver.NamedValue) error {
+	if err := checkVectorNamedValue(nv); err == nil {
+		return nil
+	}
 	if out, ok := nv.Value.(sql.Out); ok {
 		// Destination must be provided for output binding.
 		if out.Dest == nil {

--- a/internal/driver/ttc/converters/vector.go
+++ b/internal/driver/ttc/converters/vector.go
@@ -1,0 +1,320 @@
+package converters
+
+import (
+	"database/sql/driver"
+	"encoding/binary"
+	"math"
+	"strconv"
+
+	"github.com/oracle/go-oracledb/v26/internal/common"
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+	oracleErrors "github.com/oracle/go-oracledb/v26/oracle/errors"
+)
+
+const (
+	vectorTypeName            = "VECTOR"
+	maxVectorDimensions       = 65535
+	maxVectorBinaryDimensions = 65528
+
+	vectorMagic           = 0xDB
+	vectorVersionV0       = 0
+	vectorBaseHeaderBytes = 9
+	vectorNormBytes       = 8
+	vectorHeaderBytes     = vectorBaseHeaderBytes + vectorNormBytes
+
+	vectorFlagOptional   = 0x8000
+	vectorFlagLittle     = 0x0001
+	vectorFlagNorm       = 0x0002
+	vectorFlagIEEE       = 0x0008
+	vectorFlagNormSource = 0x0010
+	vectorFlagSparse     = 0x0020
+
+	vectorTypeFloat32 = 0x02
+	vectorTypeFloat64 = 0x03
+	vectorTypeInt8    = 0x04
+	vectorTypeBinary  = 0x05
+)
+
+// EncodeVectorFloat64 encodes common.VectorFloat64 into Oracle VECTOR(FLOAT64) wire layout.
+func EncodeVectorFloat64(v driver.Value) (driverCommon.B1Array, error) {
+	values, ok := v.(driverCommon.VectorFloat64)
+	if !ok {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonInvalidValue, "common.VectorFloat64")
+	}
+	if values == nil {
+		return nil, nil
+	}
+	return encodeVectorFloat64([]float64(values))
+}
+
+// EncodeVectorFloat32 encodes common.VectorFloat32 into Oracle VECTOR(FLOAT32) wire layout.
+func EncodeVectorFloat32(v driver.Value) (driverCommon.B1Array, error) {
+	values, ok := v.(driverCommon.VectorFloat32)
+	if !ok {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonInvalidValue, "common.VectorFloat32")
+	}
+	if values == nil {
+		return nil, nil
+	}
+	return encodeVectorFloat32([]float32(values))
+}
+
+// EncodeVectorInt8 encodes common.VectorInt8 into Oracle VECTOR(INT8) wire layout.
+func EncodeVectorInt8(v driver.Value) (driverCommon.B1Array, error) {
+	values, ok := v.(driverCommon.VectorInt8)
+	if !ok {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonInvalidValue, "common.VectorInt8")
+	}
+	if values == nil {
+		return nil, nil
+	}
+	return encodeVectorInt8([]int8(values))
+}
+
+// EncodeVectorBinary encodes packed bits into Oracle VECTOR(BINARY) wire layout.
+func EncodeVectorBinary(v driver.Value) (driverCommon.B1Array, error) {
+	values, ok := v.(driverCommon.VectorBinary)
+	if !ok {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonInvalidValue, "common.VectorBinary")
+	}
+	if values == nil {
+		return nil, nil
+	}
+	return encodeVectorBinary(values)
+}
+
+// DecodeVector decodes Oracle VECTOR data into the matching Go slice type:
+// []float64, []float32, []int8, or []byte (packed bits for BINARY vectors).
+func DecodeVector(data driverCommon.B1Array) (driver.Value, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	return decodeVector(data)
+}
+
+func encodeVectorFloat64(values []float64) (driverCommon.B1Array, error) {
+	if len(values) > maxVectorDimensions {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonOutOfRange, "dimensions<=65535")
+	}
+	payloadBytes := len(values) * 8
+	out := make([]byte, vectorHeaderBytes+payloadBytes)
+	writeVectorHeader(out, vectorVersionV0, vectorFlagNorm|vectorFlagNormSource, vectorTypeFloat64, uint32(len(values)))
+	offset := vectorHeaderBytes
+	for _, value := range values {
+		putOracleBinaryDouble(out[offset:offset+8], value)
+		offset += 8
+	}
+	return out, nil
+}
+
+func encodeVectorFloat32(values []float32) (driverCommon.B1Array, error) {
+	if len(values) > maxVectorDimensions {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonOutOfRange, "dimensions<=65535")
+	}
+	payloadBytes := len(values) * 4
+	out := make([]byte, vectorHeaderBytes+payloadBytes)
+	writeVectorHeader(out, vectorVersionV0, vectorFlagNorm|vectorFlagNormSource, vectorTypeFloat32, uint32(len(values)))
+	offset := vectorHeaderBytes
+	for _, value := range values {
+		putOracleBinaryFloat(out[offset:offset+4], value)
+		offset += 4
+	}
+	return out, nil
+}
+
+func encodeVectorInt8(values []int8) (driverCommon.B1Array, error) {
+	if len(values) > maxVectorDimensions {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonOutOfRange, "dimensions<=65535")
+	}
+	out := make([]byte, vectorHeaderBytes+len(values))
+	writeVectorHeader(out, vectorVersionV0, vectorFlagNorm|vectorFlagNormSource, vectorTypeInt8, uint32(len(values)))
+	for i := range values {
+		out[vectorHeaderBytes+i] = byte(values[i])
+	}
+	return out, nil
+}
+
+func encodeVectorBinary(values driverCommon.VectorBinary) (driverCommon.B1Array, error) {
+	if len(values) > maxVectorBinaryDimensions/8 {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Encode", driverCommon.ReasonOutOfRange, "dimensions<=65528")
+	}
+	out := make([]byte, vectorHeaderBytes+len(values))
+	writeVectorHeader(out, vectorVersionV0, vectorFlagNormSource, vectorTypeBinary, uint32(len(values))*8)
+	copy(out[vectorHeaderBytes:], values)
+	return out, nil
+}
+
+func writeVectorHeader(out []byte, version byte, flags uint16, typeCode byte, dimensions uint32) {
+	out[0] = vectorMagic
+	out[1] = version
+	binary.BigEndian.PutUint16(out[2:4], flags)
+	out[4] = typeCode
+	binary.BigEndian.PutUint32(out[5:9], dimensions)
+	// TTC clients reserve this FLOAT64-sized field. For numeric vectors,
+	// NORM|NORMSRC asks the database to compute the norm; BINARY reserves the
+	// field with NORMSRC because a BINARY vector has no norm. A zero value is
+	// therefore intentional, not an encoded norm calculated by this driver.
+	clear(out[vectorBaseHeaderBytes:vectorHeaderBytes])
+}
+
+func decodeVector(data []byte) (driver.Value, error) {
+	if len(data) < vectorBaseHeaderBytes {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidLength, ">="+strconv.Itoa(vectorBaseHeaderBytes))
+	}
+	if data[0] != vectorMagic {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidFormat, "magic=0xDB")
+	}
+
+	version := data[1]
+	flags := binary.BigEndian.Uint16(data[2:4])
+	typeCode := data[4]
+	dimensionCount := binary.BigEndian.Uint32(data[5:9])
+
+	if flags&vectorFlagOptional != 0 {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidFormat, "optional-flags-unsupported")
+	}
+	if flags&vectorFlagSparse != 0 {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidFormat, "sparse-unsupported")
+	}
+	if version != vectorVersionV0 {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidValue, "version=0")
+	}
+
+	valueBytes, err := vectorValueByteLength(typeCode, dimensionCount)
+	if err != nil {
+		return nil, err
+	}
+	payloadOffset := vectorBaseHeaderBytes
+	if flags&(vectorFlagNorm|vectorFlagNormSource) != 0 {
+		// The norm field is present whenever either flag is set. Accepting both
+		// forms keeps decoding compatible with clients that omit norm metadata.
+		payloadOffset += vectorNormBytes
+	}
+	expected := payloadOffset + valueBytes
+	if len(data) != expected {
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidLength, "=="+strconv.Itoa(expected))
+	}
+
+	payload := data[payloadOffset:]
+	switch typeCode {
+	case vectorTypeFloat64:
+		out := make([]float64, dimensionCount)
+		for i := range out {
+			start := i * 8
+			value, err := decodeFloat64Dimension(payload[start:start+8], flags)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = value
+		}
+		return out, nil
+	case vectorTypeFloat32:
+		out := make([]float32, dimensionCount)
+		for i := range out {
+			start := i * 4
+			value, err := decodeFloat32Dimension(payload[start:start+4], flags)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = value
+		}
+		return out, nil
+	case vectorTypeInt8:
+		out := make([]int8, dimensionCount)
+		for i := range out {
+			out[i] = int8(payload[i])
+		}
+		return out, nil
+	case vectorTypeBinary:
+		out := make([]byte, len(payload))
+		copy(out, payload)
+		return out, nil
+	default:
+		return nil, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidFormat, "type=2|3|4|5")
+	}
+}
+
+func vectorValueByteLength(typeCode byte, dimensions uint32) (int, error) {
+	switch typeCode {
+	case vectorTypeFloat64:
+		if dimensions > maxVectorDimensions {
+			return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonOutOfRange, "dimension-count")
+		}
+		return int(dimensions) * 8, nil
+	case vectorTypeFloat32:
+		if dimensions > maxVectorDimensions {
+			return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonOutOfRange, "dimension-count")
+		}
+		return int(dimensions) * 4, nil
+	case vectorTypeInt8:
+		if dimensions > maxVectorDimensions {
+			return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonOutOfRange, "dimension-count")
+		}
+		return int(dimensions), nil
+	case vectorTypeBinary:
+		if dimensions > maxVectorBinaryDimensions {
+			return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonOutOfRange, "dimension-count")
+		}
+		if dimensions%8 != 0 {
+			return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidValue, "binary-dimension-count-multiple-of-8")
+		}
+		return int(dimensions / 8), nil
+	default:
+		return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidFormat, "unknown-type")
+	}
+}
+
+func decodeFloat64Dimension(raw []byte, flags uint16) (float64, error) {
+	if len(raw) != 8 {
+		return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidLength, 8)
+	}
+	ordered := orderVectorBytes(raw, flags)
+	if (flags & vectorFlagIEEE) != 0 {
+		return math.Float64frombits(binary.BigEndian.Uint64(ordered)), nil
+	}
+	return DecodeBinaryDouble(ordered)
+}
+
+func decodeFloat32Dimension(raw []byte, flags uint16) (float32, error) {
+	if len(raw) != 4 {
+		return 0, common.NewOracleError(oracleErrors.ConverterExpectedFormat, nil, vectorTypeName, "Decode", driverCommon.ReasonInvalidLength, 4)
+	}
+	ordered := orderVectorBytes(raw, flags)
+	if (flags & vectorFlagIEEE) != 0 {
+		return math.Float32frombits(binary.BigEndian.Uint32(ordered)), nil
+	}
+	return DecodeBinaryFloat(ordered)
+}
+
+func orderVectorBytes(raw []byte, flags uint16) []byte {
+	ordered := raw
+	if (flags & vectorFlagLittle) != 0 {
+		ordered = make([]byte, len(raw))
+		for i := range raw {
+			ordered[len(raw)-1-i] = raw[i]
+		}
+	}
+	return ordered
+}
+
+func putOracleBinaryDouble(dst []byte, value float64) {
+	bits := math.Float64bits(value)
+	var stored uint64
+	if math.Signbit(value) {
+		stored = ^bits
+	} else {
+		stored = bits ^ 0x8000000000000000
+	}
+	binary.BigEndian.PutUint64(dst, stored)
+}
+
+func putOracleBinaryFloat(dst []byte, value float32) {
+	bits := math.Float32bits(value)
+	var stored uint32
+	if math.Signbit(float64(value)) {
+		stored = ^bits
+	} else {
+		stored = bits ^ 0x80000000
+	}
+	binary.BigEndian.PutUint32(dst, stored)
+}

--- a/internal/driver/ttc/converters/vector_test.go
+++ b/internal/driver/ttc/converters/vector_test.go
@@ -32,6 +32,92 @@ func TestVectorFloat64RoundTrip(t *testing.T) {
 	}
 }
 
+func TestVectorPublicEncodersValidateTypeAndNil(t *testing.T) {
+	tests := []struct {
+		name   string
+		encode func(any) (driverCommon.B1Array, error)
+		nil    any
+	}{
+		{"float64", func(v any) (driverCommon.B1Array, error) { return EncodeVectorFloat64(v) }, driverCommon.VectorFloat64(nil)},
+		{"float32", func(v any) (driverCommon.B1Array, error) { return EncodeVectorFloat32(v) }, driverCommon.VectorFloat32(nil)},
+		{"int8", func(v any) (driverCommon.B1Array, error) { return EncodeVectorInt8(v) }, driverCommon.VectorInt8(nil)},
+		{"binary", func(v any) (driverCommon.B1Array, error) { return EncodeVectorBinary(v) }, driverCommon.VectorBinary(nil)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := tc.encode(tc.nil); err != nil || got != nil {
+				t.Fatalf("nil vector: got %v, err=%v", got, err)
+			}
+			if _, err := tc.encode("not a vector"); err == nil {
+				t.Fatal("expected type validation error")
+			}
+		})
+	}
+	if got, err := DecodeVector(nil); err != nil || got != nil {
+		t.Fatalf("nil vector decode: got %v, err=%v", got, err)
+	}
+}
+
+func TestVectorDecodeWireVariantsAndBounds(t *testing.T) {
+	valid, err := EncodeVectorFloat32(driverCommon.VectorFloat32{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mutate := range []func([]byte){
+		func(data []byte) { data[2] |= 0x80 },
+		func(data []byte) { data[1] = 1 },
+		func(data []byte) { data[4] = 0xFF },
+		func(data []byte) { data[2], data[3] = 0, 0 }, // omitted norm field changes expected length
+	} {
+		data := append([]byte(nil), valid...)
+		mutate(data)
+		if _, err := DecodeVector(data); err == nil {
+			t.Fatal("expected malformed vector error")
+		}
+	}
+	if _, err := vectorValueByteLength(vectorTypeBinary, 7); err == nil {
+		t.Fatal("expected unaligned binary dimension error")
+	}
+	if _, err := vectorValueByteLength(vectorTypeFloat64, maxVectorDimensions+1); err == nil {
+		t.Fatal("expected out-of-range dimension error")
+	}
+	for _, typeCode := range []byte{vectorTypeFloat32, vectorTypeInt8, vectorTypeBinary} {
+		if _, err := vectorValueByteLength(typeCode, maxVectorDimensions+1); err == nil {
+			t.Fatalf("type %d: expected out-of-range dimension error", typeCode)
+		}
+	}
+	if _, err := vectorValueByteLength(0xFF, 1); err == nil {
+		t.Fatal("expected unknown type error")
+	}
+	if _, err := encodeVectorFloat64(make([]float64, maxVectorDimensions+1)); err == nil {
+		t.Fatal("expected FLOAT64 encode bound error")
+	}
+	if _, err := encodeVectorFloat32(make([]float32, maxVectorDimensions+1)); err == nil {
+		t.Fatal("expected FLOAT32 encode bound error")
+	}
+	if _, err := encodeVectorInt8(make([]int8, maxVectorDimensions+1)); err == nil {
+		t.Fatal("expected INT8 encode bound error")
+	}
+	if _, err := encodeVectorBinary(make(driverCommon.VectorBinary, maxVectorBinaryDimensions/8+1)); err == nil {
+		t.Fatal("expected BINARY encode bound error")
+	}
+}
+
+func TestVectorIEEEAndLittleEndianDimensions(t *testing.T) {
+	if value, err := decodeFloat64Dimension([]byte{0, 0, 0, 0, 0, 0, 0xF0, 0x3F}, vectorFlagIEEE|vectorFlagLittle); err != nil || value != 1 {
+		t.Fatalf("float64 IEEE little-endian: value=%v err=%v", value, err)
+	}
+	if value, err := decodeFloat32Dimension([]byte{0, 0, 0x20, 0x40}, vectorFlagIEEE|vectorFlagLittle); err != nil || value != 2.5 {
+		t.Fatalf("float32 IEEE little-endian: value=%v err=%v", value, err)
+	}
+	if _, err := decodeFloat64Dimension(nil, 0); err == nil {
+		t.Fatal("expected invalid float64 width")
+	}
+	if _, err := decodeFloat32Dimension(nil, 0); err == nil {
+		t.Fatal("expected invalid float32 width")
+	}
+}
+
 func TestVectorFloat32RoundTrip(t *testing.T) {
 	input := driverCommon.VectorFloat32{1.5, -2.25, 0, 3.75}
 	wire, err := EncodeVectorFloat32(input)

--- a/internal/driver/ttc/converters/vector_test.go
+++ b/internal/driver/ttc/converters/vector_test.go
@@ -1,0 +1,137 @@
+package converters
+
+import (
+	"math"
+	"testing"
+
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+)
+
+func TestVectorFloat64RoundTrip(t *testing.T) {
+	input := driverCommon.VectorFloat64{1.25, -2.5, 0, math.Pi}
+	wire, err := EncodeVectorFloat64(input)
+	if err != nil {
+		t.Fatalf("EncodeVectorFloat64 failed: %v", err)
+	}
+
+	got, err := DecodeVector(wire)
+	if err != nil {
+		t.Fatalf("DecodeVectorColumn failed: %v", err)
+	}
+	values, ok := got.([]float64)
+	if !ok {
+		t.Fatalf("decoded type mismatch: got %T want []float64", got)
+	}
+	if len(values) != len(input) {
+		t.Fatalf("decoded length mismatch: got %d want %d", len(values), len(input))
+	}
+	for i := range input {
+		if values[i] != input[i] {
+			t.Fatalf("decoded value mismatch at %d: got %v want %v", i, values[i], input[i])
+		}
+	}
+}
+
+func TestVectorFloat32RoundTrip(t *testing.T) {
+	input := driverCommon.VectorFloat32{1.5, -2.25, 0, 3.75}
+	wire, err := EncodeVectorFloat32(input)
+	if err != nil {
+		t.Fatalf("EncodeVectorFloat32 failed: %v", err)
+	}
+
+	got, err := DecodeVector(wire)
+	if err != nil {
+		t.Fatalf("DecodeVectorColumn failed: %v", err)
+	}
+	values, ok := got.([]float32)
+	if !ok {
+		t.Fatalf("decoded type mismatch: got %T want []float32", got)
+	}
+	if len(values) != len(input) {
+		t.Fatalf("decoded length mismatch: got %d want %d", len(values), len(input))
+	}
+	for i := range input {
+		if values[i] != input[i] {
+			t.Fatalf("decoded value mismatch at %d: got %v want %v", i, values[i], input[i])
+		}
+	}
+}
+
+func TestVectorInt8RoundTrip(t *testing.T) {
+	input := driverCommon.VectorInt8{1, -2, 0, 127, -128}
+	wire, err := EncodeVectorInt8(input)
+	if err != nil {
+		t.Fatalf("EncodeVectorInt8 failed: %v", err)
+	}
+
+	got, err := DecodeVector(wire)
+	if err != nil {
+		t.Fatalf("DecodeVectorColumn failed: %v", err)
+	}
+	values, ok := got.([]int8)
+	if !ok {
+		t.Fatalf("decoded type mismatch: got %T want []int8", got)
+	}
+	if len(values) != len(input) {
+		t.Fatalf("decoded length mismatch: got %d want %d", len(values), len(input))
+	}
+	for i := range input {
+		if values[i] != input[i] {
+			t.Fatalf("decoded value mismatch at %d: got %v want %v", i, values[i], input[i])
+		}
+	}
+}
+
+func TestVectorBinaryRoundTrip(t *testing.T) {
+	input := driverCommon.VectorBinary{0xA5, 0x0F}
+	wire, err := EncodeVectorBinary(input)
+	if err != nil {
+		t.Fatalf("EncodeVectorBinary failed: %v", err)
+	}
+
+	got, err := DecodeVector(wire)
+	if err != nil {
+		t.Fatalf("DecodeVectorColumn failed: %v", err)
+	}
+	values, ok := got.([]byte)
+	if !ok {
+		t.Fatalf("decoded type mismatch: got %T want []byte", got)
+	}
+	if len(values) != len(input) {
+		t.Fatalf("decoded length mismatch: got %d want %d", len(values), len(input))
+	}
+	for i := range input {
+		if values[i] != input[i] {
+			t.Fatalf("decoded value mismatch at %d: got %v want %v", i, values[i], input[i])
+		}
+	}
+}
+
+func TestDecodeVectorRejectsMalformedPayload(t *testing.T) {
+	valid, err := EncodeVectorFloat32(driverCommon.VectorFloat32{1})
+	if err != nil {
+		t.Fatalf("encode valid vector: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		data driverCommon.B1Array
+	}{
+		{name: "short header", data: driverCommon.B1Array{vectorMagic}},
+		{name: "invalid magic", data: append(driverCommon.B1Array{0}, valid[1:]...)},
+		{name: "sparse vector", data: func() driverCommon.B1Array {
+			data := append(driverCommon.B1Array(nil), valid...)
+			data[3] |= byte(vectorFlagSparse)
+			return data
+		}()},
+		{name: "invalid payload length", data: valid[:len(valid)-1]},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeVector(tc.data); err == nil {
+				t.Fatal("expected malformed vector to fail decoding")
+			}
+		})
+	}
+}

--- a/internal/driver/ttc/pkg_init.go
+++ b/internal/driver/ttc/pkg_init.go
@@ -768,6 +768,18 @@ func init() {
 	if err := EncoderRegistry.Register(reflect.TypeOf(float64(0)), MinTTCProtocolVersion, converters.EncodeFloat); err != nil {
 		common.Odl.Warn("Failed to register float64 encoder", "error", err)
 	}
+	if err := EncoderRegistry.Register(reflect.TypeOf(driverCommon.VectorFloat64(nil)), MinTTCProtocolVersion, converters.EncodeVectorFloat64); err != nil {
+		common.Odl.Warn("Failed to register VectorFloat64 encoder", "error", err)
+	}
+	if err := EncoderRegistry.Register(reflect.TypeOf(driverCommon.VectorFloat32(nil)), MinTTCProtocolVersion, converters.EncodeVectorFloat32); err != nil {
+		common.Odl.Warn("Failed to register VectorFloat32 encoder", "error", err)
+	}
+	if err := EncoderRegistry.Register(reflect.TypeOf(driverCommon.VectorInt8(nil)), MinTTCProtocolVersion, converters.EncodeVectorInt8); err != nil {
+		common.Odl.Warn("Failed to register VectorInt8 encoder", "error", err)
+	}
+	if err := EncoderRegistry.Register(reflect.TypeOf(driverCommon.VectorBinary(nil)), MinTTCProtocolVersion, converters.EncodeVectorBinary); err != nil {
+		common.Odl.Warn("Failed to register VectorBinary encoder", "error", err)
+	}
 	if err := EncoderRegistry.Register(reflect.TypeOf(time.Time{}), MinTTCProtocolVersion, converters.EncodeTimestampWithTimeZone); err != nil {
 		common.Odl.Warn("Failed to register time.Time encoder", "error", err)
 	}
@@ -884,6 +896,9 @@ func init() {
 		GetScanTypeForBinaryColumn)); err != nil {
 		common.Odl.Warn("Failed to register binary decoder", "error", err)
 	}
+	if err := DecoderRegistry.Register(DtyVec, MinTTCProtocolVersion, newTypeDecoder(DecodeVectorColumn, nil)); err != nil {
+		common.Odl.Warn("Failed to register VECTOR decoder", "error", err)
+	}
 
 	if err := DecoderRegistry.Register(DtyClob, MinTTCProtocolVersion,
 		newTypeDecoder(DecodeClob, GetScanTypeForCLOBColumn)); err != nil {
@@ -940,6 +955,22 @@ func init() {
 	if err := BindOacRegistry.Register(reflect.TypeOf(float64(0)), MinTTCProtocolVersion, bindOacType{bindOacFunc: func(driverCommon.UB4) driverCommon.Marshallable { return newTTIOacNumber() }, maxLength: converters.MaxNumberLength, scale: driverCommon.SB1(NumberScaleFloatSentinel)}); err != nil {
 		common.Odl.Warn("Failed to register float64 bind OAC", "error", err)
 	}
+	for _, vectorType := range []reflect.Type{
+		reflect.TypeOf(driverCommon.VectorFloat64(nil)),
+		reflect.TypeOf(driverCommon.VectorFloat32(nil)),
+		reflect.TypeOf(driverCommon.VectorInt8(nil)),
+		reflect.TypeOf(driverCommon.VectorBinary(nil)),
+	} {
+		if err := BindOacRegistry.Register(vectorType, MinTTCProtocolVersion, bindOacType{
+			bindOacFunc: func(maxLength driverCommon.UB4) driverCommon.Marshallable { return newTTIoac(DtyVec, maxLength) },
+			maxLength:   converters.MaxVarcharLength,
+		}); err != nil {
+			common.Odl.Warn("Failed to register VECTOR bind OAC", "type", vectorType, "error", err)
+		}
+		if err := BindValueRegistry.Register(vectorType, MinTTCProtocolVersion, buildVectorBindValue); err != nil {
+			common.Odl.Warn("Failed to register VECTOR bind transport", "type", vectorType, "error", err)
+		}
+	}
 	if err := BindOacRegistry.Register(reflect.TypeOf([]byte(nil)), MinTTCProtocolVersion, bindOacType{bindOacFunc: newTTIOacBytes, maxLength: 32767}); err != nil {
 		common.Odl.Warn("Failed to register []byte bind OAC", "error", err)
 	}
@@ -964,6 +995,9 @@ func init() {
 	// JSON currently uses a BLOB-based define OAC with max length 4000.
 	if err := DefineOacRegistry.Register(DtyJSON, MinTTCProtocolVersion, newTTIOacJSONDefine); err != nil {
 		common.Odl.Warn("Failed to register JSON define OAC", "error", err)
+	}
+	if err := DefineOacRegistry.Register(DtyVec, MinTTCProtocolVersion, newTTIOacVectorDefine); err != nil {
+		common.Odl.Warn("Failed to register VECTOR define OAC", "error", err)
 	}
 
 	if err := DefineOacRegistry.Register(DtyClob, MinTTCProtocolVersion, newTTIOacClobDefine); err != nil {

--- a/internal/driver/ttc/pkg_init.go
+++ b/internal/driver/ttc/pkg_init.go
@@ -967,9 +967,6 @@ func init() {
 		}); err != nil {
 			common.Odl.Warn("Failed to register VECTOR bind OAC", "type", vectorType, "error", err)
 		}
-		if err := BindValueRegistry.Register(vectorType, MinTTCProtocolVersion, buildVectorBindValue); err != nil {
-			common.Odl.Warn("Failed to register VECTOR bind transport", "type", vectorType, "error", err)
-		}
 	}
 	if err := BindOacRegistry.Register(reflect.TypeOf([]byte(nil)), MinTTCProtocolVersion, bindOacType{bindOacFunc: newTTIOacBytes, maxLength: 32767}); err != nil {
 		common.Odl.Warn("Failed to register []byte bind OAC", "error", err)

--- a/internal/driver/ttc/statement_executors.go
+++ b/internal/driver/ttc/statement_executors.go
@@ -670,9 +670,10 @@ func (e *statementProcessor) prepareBindsAndOAC(args []sqldriver.Value) error {
 		if err != nil {
 			return err
 		}
-		e.encodedValues[currentRow][i], err = e.shelf.GetCodecFactory().getBindValue(normalized, encoded)
-		if err != nil {
-			return err
+		if isVectorBindType(normalized.goType) {
+			e.encodedValues[currentRow][i] = newVectorBindValue(encoded)
+		} else {
+			e.encodedValues[currentRow][i] = newCLRBindValue(encoded)
 		}
 
 		e.currentOacs[i], err = e.shelf.GetCodecFactory().getBindOac(

--- a/internal/driver/ttc/statement_executors.go
+++ b/internal/driver/ttc/statement_executors.go
@@ -132,7 +132,7 @@ type statementProcessor struct {
 	opts          driverCommon.UB4                    // OALL8 option bitmask (parse/execute/commit/no-PLSQL/binds-present flags etc).
 	al8i4         []driverCommon.UB4                  // AL8I4 options vector attached to OALL8 (iterations, select flag, extra protocol flags).
 	bindValues    []any                               // Original bind values (ordered by position) for the current execution.
-	encodedValues [][]driverCommon.B1Array            // Wire-encoded bind payloads per iteration (each inner slice is a TTIRXD bind row).
+	encodedValues [][]bindValue                       // Wire-encoded bind payloads per iteration (each inner slice is a TTIRXD bind row).
 	currentOacs   []driverCommon.Marshallable         // Per-bind OAC descriptors (type/size metadata) sent alongside bind values.
 	previousOacs  []driverCommon.Marshallable         // Cached OACs from previous execution of the statement
 }
@@ -652,9 +652,9 @@ func (e *statementProcessor) prepareBindsAndOAC(args []sqldriver.Value) error {
 	e.bindValues = make([]any, n)
 	// TODO : currently, just do it for single row, later when
 	//        batching support is added, make it dynamic.
-	e.encodedValues = make([][]driverCommon.B1Array, 1)
+	e.encodedValues = make([][]bindValue, 1)
 	currentRow := 0
-	e.encodedValues[currentRow] = make([]driverCommon.B1Array, n)
+	e.encodedValues[currentRow] = make([]bindValue, n)
 	e.currentOacs = make([]driverCommon.Marshallable, n)
 	for i, v := range args {
 		e.bindValues[i] = v
@@ -666,14 +666,18 @@ func (e *statementProcessor) prepareBindsAndOAC(args []sqldriver.Value) error {
 			return err
 		}
 
-		e.encodedValues[currentRow][i], err = encoder(normalized.value)
+		encoded, err := encoder(normalized.value)
+		if err != nil {
+			return err
+		}
+		e.encodedValues[currentRow][i], err = e.shelf.GetCodecFactory().getBindValue(normalized, encoded)
 		if err != nil {
 			return err
 		}
 
 		e.currentOacs[i], err = e.shelf.GetCodecFactory().getBindOac(
 			normalized,
-			e.getMaxLengthForOac(i, len(e.encodedValues[currentRow][i])),
+			e.getMaxLengthForOac(i, len(encoded)),
 		)
 		if err != nil {
 			return err

--- a/internal/driver/ttc/statement_executors_2_test.go
+++ b/internal/driver/ttc/statement_executors_2_test.go
@@ -291,7 +291,7 @@ func TestPrepareBindsAndOAC_Encode_Supported(t *testing.T) {
 	if !bytes.Equal(row[2].payload, []byte{1, 2, 3}) {
 		t.Fatalf("raw encoding mismatch: got %v want %v", row[2].payload, []byte{1, 2, 3})
 	}
-	if !row[3].isNull {
+	if row[3].payload != nil {
 		t.Fatalf("nil bind should encode as nil cell, got %v", row[3])
 	}
 	// bool -> representation per current impl

--- a/internal/driver/ttc/statement_executors_2_test.go
+++ b/internal/driver/ttc/statement_executors_2_test.go
@@ -281,29 +281,29 @@ func TestPrepareBindsAndOAC_Encode_Supported(t *testing.T) {
 	}
 
 	expNum, _ := converters.EncodeInt(42)
-	if !bytes.Equal([]byte(row[0]), []byte(expNum)) {
-		t.Fatalf("int64 encoding mismatch: got %v want %v", []byte(row[0]), []byte(expNum))
+	if !bytes.Equal(row[0].payload, expNum) {
+		t.Fatalf("int64 encoding mismatch: got %v want %v", row[0].payload, expNum)
 	}
 	expVcs, _ := converters.EncodeVarchar("X")
-	if !bytes.Equal([]byte(row[1]), []byte(expVcs)) {
-		t.Fatalf("varchar encoding mismatch: got %v want %v", []byte(row[1]), []byte(expVcs))
+	if !bytes.Equal(row[1].payload, expVcs) {
+		t.Fatalf("varchar encoding mismatch: got %v want %v", row[1].payload, expVcs)
 	}
-	if !bytes.Equal([]byte(row[2]), []byte{1, 2, 3}) {
-		t.Fatalf("raw encoding mismatch: got %v want %v", []byte(row[2]), []byte{1, 2, 3})
+	if !bytes.Equal(row[2].payload, []byte{1, 2, 3}) {
+		t.Fatalf("raw encoding mismatch: got %v want %v", row[2].payload, []byte{1, 2, 3})
 	}
-	if row[3] != nil {
+	if !row[3].isNull {
 		t.Fatalf("nil bind should encode as nil cell, got %v", row[3])
 	}
 	// bool -> representation per current impl
-	if !bytes.Equal([]byte(row[4]), []byte{1, 1}) {
-		t.Fatalf("bool(true) encoding mismatch: got %v want %v", []byte(row[4]), []byte{1})
+	if !bytes.Equal(row[4].payload, []byte{1, 1}) {
+		t.Fatalf("bool(true) encoding mismatch: got %v want %v", row[4].payload, []byte{1})
 	}
-	if !bytes.Equal([]byte(row[5]), []byte{0}) {
-		t.Fatalf("bool(false) encoding mismatch: got %v want %v", []byte(row[5]), []byte{0})
+	if !bytes.Equal(row[5].payload, []byte{0}) {
+		t.Fatalf("bool(false) encoding mismatch: got %v want %v", row[5].payload, []byte{0})
 	}
 	expTS, _ := converters.EncodeTimestampWithTimeZone(ts)
-	if !bytes.Equal([]byte(row[6]), []byte(expTS)) {
-		t.Fatalf("timestamp encoding mismatch: got %v want %v", []byte(row[6]), []byte(expTS))
+	if !bytes.Equal(row[6].payload, expTS) {
+		t.Fatalf("timestamp encoding mismatch: got %v want %v", row[6].payload, expTS)
 	}
 }
 

--- a/internal/driver/ttc/ttioac.go
+++ b/internal/driver/ttc/ttioac.go
@@ -236,6 +236,14 @@ func newTTIOacJSONDefine(columnContext columnContext, lobPrefetchSize driverComm
 	return newTTIOAcDefine(DtyBlob, max_lob_length, columnContext, uacfsald, lobPrefetchSize)
 }
 
+const vectorPrefetchSize driverCommon.UB4 = 524308
+
+// newTTIOacVectorDefine creates a define OAC descriptor for VECTOR values with LOB prefetch enabled.
+// The fixed prefetch covers the largest dense FLOAT64 VECTOR envelope.
+func newTTIOacVectorDefine(columnContext columnContext, _ driverCommon.UB4) driverCommon.Marshallable {
+	return newTTIOAcDefine(DtyVec, max_lob_length, columnContext, uacfsald, vectorPrefetchSize)
+}
+
 // newTTIOacClobDefine creates a define OAC descriptor for CLOB values using column metadata and LOB prefetch settings.
 func newTTIOacClobDefine(columnContext columnContext, lobPrefetchSize driverCommon.UB4) driverCommon.Marshallable {
 	return newTTIOAcDefine(columnContext.DataType, max_lob_length, columnContext, 0, lobPrefetchSize)

--- a/internal/driver/ttc/ttirxd.go
+++ b/internal/driver/ttc/ttirxd.go
@@ -70,7 +70,7 @@ type tTIrxd struct {
 	bvcFound bool
 
 	// Outgoing bind payload for TTIRXD when marshalling bind values (Phase 1: single row binds).
-	bindRow        []driverCommon.B1Array
+	bindRow        []bindValue
 	columnContexts []columnContext
 	lobColContext  []*lobColumnContext
 
@@ -155,7 +155,7 @@ Parameters:
        Each element should contain the wire-format bytes for that column (nil indicates SQL NULL).
 */
 
-func (rxd *tTIrxd) setBindValues(row []driverCommon.B1Array) {
+func (rxd *tTIrxd) setBindValues(row []bindValue) {
 	rxd.bindRow = row
 }
 
@@ -173,21 +173,8 @@ func (rxd *tTIrxd) MarshalTo(ctx context.Context, engine driverCommon.Marshaller
 	}
 	bindCount := len(rxd.bindRow)
 	for i := 0; i < bindCount; i++ {
-		val := rxd.bindRow[i]
-		if val == nil {
-			// Write CLR null indicator
-			if err := engine.MarshalUB1(ctx, driverCommon.UB1(0)); err != nil {
-				common.Odl.Error("tTIrxd.MarshalTo: failed to write null length indicator",
-					"error", err, "stage", "null-indicator", "index", i)
-				return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[rxd.GetMsgCode()])
-			}
-			continue
-		}
-		// Write as CLR (short or long form depending on size)
-		if err := engine.MarshalCLR(ctx, val, 0, len(val)); err != nil {
-			common.Odl.Error("tTIrxd.MarshalTo: failed to write CLR",
-				"error", err, "stage", "clr", "index", i)
-			return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[rxd.GetMsgCode()])
+		if err := rxd.bindRow[i].marshal(ctx, engine, rxd.GetMsgCode(), i); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -339,6 +326,11 @@ Errors:
 */
 func (rxd *tTIrxd) _unmarshalColumn(ctx context.Context, dtyType DtyType, mar driverCommon.Marshaller, col int) error {
 	switch dtyType {
+	case DtyVec:
+		if err := rxd._unmarshalVectorColumn(ctx, mar, col); err != nil {
+			return err
+		}
+		rxd.lobColContext = append(rxd.lobColContext, nil)
 	case DtyClob:
 		if err := rxd._unmarshalClobColumn(ctx, mar, col); err != nil {
 			return err

--- a/internal/driver/ttc/ttirxd_returning_test.go
+++ b/internal/driver/ttc/ttirxd_returning_test.go
@@ -398,7 +398,7 @@ func TestTTIrxd_MarshalTo_LargeCLR(t *testing.T) {
 	for i := range large {
 		large[i] = byte(i & 0xFF)
 	}
-	rxd.setBindValues([]common.B1Array{large})
+	rxd.setBindValues([]bindValue{newCLRBindValue(large)})
 
 	buf, eng := NewMarshalEngineTest(common.BIG_ENDIAN, B2, Universal, 1024)
 

--- a/internal/driver/ttc/ttirxd_test.go
+++ b/internal/driver/ttc/ttirxd_test.go
@@ -116,7 +116,7 @@ func TestTTIrxd_MarshalTo_Success(t *testing.T) {
 
 	// Encoded bind data set before calling MarshalTo (nil, then 3-byte value)
 	val := common.B1Array{0x01, 0x02, 0x03}
-	rxd.setBindValues([]common.B1Array{nil, val})
+	rxd.setBindValues([]bindValue{newCLRBindValue(nil), newCLRBindValue(val)})
 
 	// Use ArrayBasedDataBuffer via NewMarshalEngineTest so we can inspect bytes directly
 	buf, eng := NewMarshalEngineTest(common.BIG_ENDIAN, B2, Universal, 64)
@@ -138,7 +138,7 @@ func TestTTIrxd_MarshalTo_Success(t *testing.T) {
 func TestTTIrxd_MarshalTo_FailOnNullIndicator(t *testing.T) {
 	t.Parallel()
 	rxd := newTTIrxd().(*tTIrxd)
-	rxd.setBindValues([]common.B1Array{nil})
+	rxd.setBindValues([]bindValue{newCLRBindValue(nil)})
 
 	// Fail the first WriteByteWithContext call (which writes the null indicator)
 	mar := createMarshaller(make([]byte, 8), failOnWriteByte, 1)
@@ -162,7 +162,7 @@ func TestTTIrxd_MarshalTo_FailOnNullIndicator(t *testing.T) {
 func TestTTIrxd_MarshalTo_FailOnCLRDataWrite(t *testing.T) {
 	t.Parallel()
 	rxd := newTTIrxd().(*tTIrxd)
-	rxd.setBindValues([]common.B1Array{{0xAA, 0xBB, 0xCC}})
+	rxd.setBindValues([]bindValue{newCLRBindValue(common.B1Array{0xAA, 0xBB, 0xCC})})
 
 	// First WriteBytesWithContext call should fail (after successful length byte write)
 	mar := createMarshaller(make([]byte, 8), failOnWriteBytes, 1)

--- a/internal/driver/ttc/ttishelf_test.go
+++ b/internal/driver/ttc/ttishelf_test.go
@@ -193,10 +193,6 @@ func (t *testCodecFactory) getDecoder(_ DtyType) (*typeDecoder, error) {
 	}, nil), nil
 }
 
-func (t *testCodecFactory) getBindValue(_ normalizedBindValue, payload driverCommon.B1Array) (bindValue, error) {
-	return newCLRBindValue(payload), nil
-}
-
 func (t *testCodecFactory) getBindOac(_ normalizedBindValue, _ driverCommon.UB4) (driverCommon.Marshallable, error) {
 	return t.bindOac, nil
 }

--- a/internal/driver/ttc/ttishelf_test.go
+++ b/internal/driver/ttc/ttishelf_test.go
@@ -192,6 +192,11 @@ func (t *testCodecFactory) getDecoder(_ DtyType) (*typeDecoder, error) {
 		return t.decode, nil
 	}, nil), nil
 }
+
+func (t *testCodecFactory) getBindValue(_ normalizedBindValue, payload driverCommon.B1Array) (bindValue, error) {
+	return newCLRBindValue(payload), nil
+}
+
 func (t *testCodecFactory) getBindOac(_ normalizedBindValue, _ driverCommon.UB4) (driverCommon.Marshallable, error) {
 	return t.bindOac, nil
 }

--- a/internal/driver/ttc/type_codec_factory.go
+++ b/internal/driver/ttc/type_codec_factory.go
@@ -90,6 +90,7 @@ Description:
 type codecFactory interface {
 	getEncoder(normalizedBindValue) (encoderFunc, error)
 	getDecoder(DtyType) (*typeDecoder, error)
+	getBindValue(normalizedBindValue, driverCommon.B1Array) (bindValue, error)
 	getBindOac(normalizedBindValue, driverCommon.UB4) (driverCommon.Marshallable, error)
 	getDefineOac(DtyType, columnContext, driverCommon.DriverProperties) driverCommon.Marshallable
 }
@@ -108,6 +109,9 @@ type decoderFunc func(columnContext, driverCommon.B1Array) (driver.Value, error)
 // with the codec factory. The function receives the requested maximum bind length
 // and must return a TTC OAC descriptor suitable for marshalling bind metadata.
 type bindOacFunc func(driverCommon.UB4) driverCommon.Marshallable
+
+// bindValueBuilder prepares a bind value whose TTC representation differs from CLR.
+type bindValueBuilder func(normalizedBindValue, driverCommon.B1Array) (bindValue, error)
 
 // bindOacType stores a bind OAC constructor together with the default max-length
 // and scale metadata that should be applied for OUT bind handling.
@@ -382,6 +386,9 @@ var DecoderRegistry = newCodecRegistry[DtyType, *typeDecoder]()
 // BindOacRegistry is the global registry for bind OAC metadata keyed by Go type.
 var BindOacRegistry = newCodecRegistry[reflect.Type, bindOacType]()
 
+// BindValueRegistry is the global registry for type-specific bind transports.
+var BindValueRegistry = newCodecRegistry[reflect.Type, bindValueBuilder]()
+
 // DefineOacRegistry is the global registry for define OAC instances keyed by Oracle database type,
 // column context and connection properties.
 var DefineOacRegistry = newCodecRegistry[DtyType, defineOacFunc]()
@@ -401,6 +408,7 @@ type CodecFactoryImpl struct {
 	ttcVersion int8
 	encoders   *codecRegistry[reflect.Type, encoderFunc]
 	decoders   *codecRegistry[DtyType, *typeDecoder]
+	bindValues *codecRegistry[reflect.Type, bindValueBuilder]
 	bindOacs   *codecRegistry[reflect.Type, bindOacType]
 	defineOacs *codecRegistry[DtyType, defineOacFunc]
 }
@@ -427,6 +435,7 @@ func NewCodecFactoryForProtocol(protocolVersion int8) codecFactory {
 		ttcVersion: protocolVersion,
 		encoders:   EncoderRegistry,
 		decoders:   DecoderRegistry,
+		bindValues: BindValueRegistry,
 		bindOacs:   BindOacRegistry,
 		defineOacs: DefineOacRegistry,
 	}
@@ -501,6 +510,16 @@ func (f *CodecFactoryImpl) getDecoder(dbType DtyType) (*typeDecoder, error) {
 
 	common.Odl.Debug("Decoder returned", "candidate", bestCandidate)
 	return bestCandidate.makeFunc, nil
+}
+
+// getBindValue returns the type-specific TTC transport for an encoded bind.
+// Values without a registered transport use ordinary CLR marshalling.
+func (f *CodecFactoryImpl) getBindValue(normalized normalizedBindValue, payload driverCommon.B1Array) (bindValue, error) {
+	candidates := f.bindValues.getCandidates(normalized.goType)
+	if bestCandidate := getEntryFromRegistry(f.ttcVersion, candidates); bestCandidate != nil {
+		return bestCandidate.makeFunc(normalized, payload)
+	}
+	return newCLRBindValue(payload), nil
 }
 
 /*

--- a/internal/driver/ttc/type_codec_factory.go
+++ b/internal/driver/ttc/type_codec_factory.go
@@ -90,7 +90,6 @@ Description:
 type codecFactory interface {
 	getEncoder(normalizedBindValue) (encoderFunc, error)
 	getDecoder(DtyType) (*typeDecoder, error)
-	getBindValue(normalizedBindValue, driverCommon.B1Array) (bindValue, error)
 	getBindOac(normalizedBindValue, driverCommon.UB4) (driverCommon.Marshallable, error)
 	getDefineOac(DtyType, columnContext, driverCommon.DriverProperties) driverCommon.Marshallable
 }
@@ -109,9 +108,6 @@ type decoderFunc func(columnContext, driverCommon.B1Array) (driver.Value, error)
 // with the codec factory. The function receives the requested maximum bind length
 // and must return a TTC OAC descriptor suitable for marshalling bind metadata.
 type bindOacFunc func(driverCommon.UB4) driverCommon.Marshallable
-
-// bindValueBuilder prepares a bind value whose TTC representation differs from CLR.
-type bindValueBuilder func(normalizedBindValue, driverCommon.B1Array) (bindValue, error)
 
 // bindOacType stores a bind OAC constructor together with the default max-length
 // and scale metadata that should be applied for OUT bind handling.
@@ -386,9 +382,6 @@ var DecoderRegistry = newCodecRegistry[DtyType, *typeDecoder]()
 // BindOacRegistry is the global registry for bind OAC metadata keyed by Go type.
 var BindOacRegistry = newCodecRegistry[reflect.Type, bindOacType]()
 
-// BindValueRegistry is the global registry for type-specific bind transports.
-var BindValueRegistry = newCodecRegistry[reflect.Type, bindValueBuilder]()
-
 // DefineOacRegistry is the global registry for define OAC instances keyed by Oracle database type,
 // column context and connection properties.
 var DefineOacRegistry = newCodecRegistry[DtyType, defineOacFunc]()
@@ -408,7 +401,6 @@ type CodecFactoryImpl struct {
 	ttcVersion int8
 	encoders   *codecRegistry[reflect.Type, encoderFunc]
 	decoders   *codecRegistry[DtyType, *typeDecoder]
-	bindValues *codecRegistry[reflect.Type, bindValueBuilder]
 	bindOacs   *codecRegistry[reflect.Type, bindOacType]
 	defineOacs *codecRegistry[DtyType, defineOacFunc]
 }
@@ -435,7 +427,6 @@ func NewCodecFactoryForProtocol(protocolVersion int8) codecFactory {
 		ttcVersion: protocolVersion,
 		encoders:   EncoderRegistry,
 		decoders:   DecoderRegistry,
-		bindValues: BindValueRegistry,
 		bindOacs:   BindOacRegistry,
 		defineOacs: DefineOacRegistry,
 	}
@@ -510,16 +501,6 @@ func (f *CodecFactoryImpl) getDecoder(dbType DtyType) (*typeDecoder, error) {
 
 	common.Odl.Debug("Decoder returned", "candidate", bestCandidate)
 	return bestCandidate.makeFunc, nil
-}
-
-// getBindValue returns the type-specific TTC transport for an encoded bind.
-// Values without a registered transport use ordinary CLR marshalling.
-func (f *CodecFactoryImpl) getBindValue(normalized normalizedBindValue, payload driverCommon.B1Array) (bindValue, error) {
-	candidates := f.bindValues.getCandidates(normalized.goType)
-	if bestCandidate := getEntryFromRegistry(f.ttcVersion, candidates); bestCandidate != nil {
-		return bestCandidate.makeFunc(normalized, payload)
-	}
-	return newCLRBindValue(payload), nil
 }
 
 /*

--- a/internal/driver/ttc/type_decoder.go
+++ b/internal/driver/ttc/type_decoder.go
@@ -575,6 +575,15 @@ func DecodeBinaryColumn(_ columnContext, data driverCommon.B1Array) (driver.Valu
 	return []byte(data), nil
 }
 
+// DecodeVectorColumn decodes a fully prefetched TTC VECTOR envelope.
+func DecodeVectorColumn(columnContext columnContext, data driverCommon.B1Array) (driver.Value, error) {
+	value, err := converters.DecodeVector(data)
+	if err != nil {
+		return nil, rowDecodeError(columnContext, err, "VECTOR")
+	}
+	return value, nil
+}
+
 func GetScanTypeForVarcharColumn(_ columnContext) reflect.Type {
 	return reflect.TypeFor[string]()
 }

--- a/internal/driver/ttc/vector_bind_support.go
+++ b/internal/driver/ttc/vector_bind_support.go
@@ -36,30 +36,19 @@ func checkVectorNamedValue(nv *driver.NamedValue) error {
 	return driver.ErrSkip
 }
 
-type vectorBindTransport struct {
-	locator driverCommon.B1Array
+func newVectorBindValue(payload driverCommon.B1Array) bindValue {
+	return bindValue{kind: bindValueKindVector, payload: payload}
 }
 
-func buildVectorBindValue(_ normalizedBindValue, payload driverCommon.B1Array) (bindValue, error) {
-	transport := &vectorBindTransport{}
-	if payload != nil {
-		transport.locator = buildVectorQuasiLocator(len(payload))
-	}
-	return bindValue{
-		transport: transport,
-		payload:   payload,
-		isNull:    payload == nil,
-	}, nil
-}
-
-func (t *vectorBindTransport) marshal(
+// marshalVectorBind writes the native VECTOR payload with its BLOB quasi-locator.
+func marshalVectorBind(
 	ctx context.Context,
 	engine driverCommon.Marshaller,
 	msgCode driverCommon.MessageType,
 	index int,
-	bind bindValue,
+	payload driverCommon.B1Array,
 ) error {
-	if bind.isNull {
+	if payload == nil {
 		if err := engine.MarshalUB4(ctx, 0); err != nil {
 			common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector null length",
 				"error", err, "stage", "vector-null-length", "index", index)
@@ -68,18 +57,19 @@ func (t *vectorBindTransport) marshal(
 		return nil
 	}
 
-	locLen := len(t.locator)
+	locator := buildVectorQuasiLocator(len(payload))
+	locLen := len(locator)
 	if err := engine.MarshalUB4(ctx, driverCommon.UB4(locLen)); err != nil {
 		common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector locator length",
 			"error", err, "stage", "vector-locator-length", "index", index)
 		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
 	}
-	if err := engine.MarshalCLR(ctx, t.locator, 0, locLen); err != nil {
+	if err := engine.MarshalCLR(ctx, locator, 0, locLen); err != nil {
 		common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector locator",
 			"error", err, "stage", "vector-locator", "index", index)
 		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
 	}
-	if err := engine.MarshalCLR(ctx, bind.payload, 0, len(bind.payload)); err != nil {
+	if err := engine.MarshalCLR(ctx, payload, 0, len(payload)); err != nil {
 		common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector payload",
 			"error", err, "stage", "vector-payload", "index", index)
 		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])

--- a/internal/driver/ttc/vector_bind_support.go
+++ b/internal/driver/ttc/vector_bind_support.go
@@ -1,0 +1,88 @@
+package ttc
+
+import (
+	"context"
+	"database/sql/driver"
+	"reflect"
+
+	"github.com/oracle/go-oracledb/v26/internal/common"
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+	oracleErrors "github.com/oracle/go-oracledb/v26/oracle/errors"
+)
+
+var (
+	vectorFloat64Type = reflect.TypeOf(driverCommon.VectorFloat64(nil))
+	vectorFloat32Type = reflect.TypeOf(driverCommon.VectorFloat32(nil))
+	vectorInt8Type    = reflect.TypeOf(driverCommon.VectorInt8(nil))
+	vectorBinaryType  = reflect.TypeOf(driverCommon.VectorBinary(nil))
+)
+
+func isVectorBindType(goType reflect.Type) bool {
+	switch goType {
+	case vectorFloat64Type, vectorFloat32Type, vectorInt8Type, vectorBinaryType:
+		return true
+	default:
+		return false
+	}
+}
+
+func checkVectorNamedValue(nv *driver.NamedValue) error {
+	if nv == nil {
+		return driver.ErrSkip
+	}
+	if isVectorBindType(reflect.TypeOf(nv.Value)) {
+		return nil
+	}
+	return driver.ErrSkip
+}
+
+type vectorBindTransport struct {
+	locator driverCommon.B1Array
+}
+
+func buildVectorBindValue(_ normalizedBindValue, payload driverCommon.B1Array) (bindValue, error) {
+	transport := &vectorBindTransport{}
+	if payload != nil {
+		transport.locator = buildVectorQuasiLocator(len(payload))
+	}
+	return bindValue{
+		transport: transport,
+		payload:   payload,
+		isNull:    payload == nil,
+	}, nil
+}
+
+func (t *vectorBindTransport) marshal(
+	ctx context.Context,
+	engine driverCommon.Marshaller,
+	msgCode driverCommon.MessageType,
+	index int,
+	bind bindValue,
+) error {
+	if bind.isNull {
+		if err := engine.MarshalUB4(ctx, 0); err != nil {
+			common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector null length",
+				"error", err, "stage", "vector-null-length", "index", index)
+			return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
+		}
+		return nil
+	}
+
+	locLen := len(t.locator)
+	if err := engine.MarshalUB4(ctx, driverCommon.UB4(locLen)); err != nil {
+		common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector locator length",
+			"error", err, "stage", "vector-locator-length", "index", index)
+		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
+	}
+	if err := engine.MarshalCLR(ctx, t.locator, 0, locLen); err != nil {
+		common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector locator",
+			"error", err, "stage", "vector-locator", "index", index)
+		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
+	}
+	if err := engine.MarshalCLR(ctx, bind.payload, 0, len(bind.payload)); err != nil {
+		common.Odl.Error("tTIrxd.MarshalTo: failed to marshal vector payload",
+			"error", err, "stage", "vector-payload", "index", index)
+		return common.NewOracleError(oracleErrors.FailMarshal, err, TTCMsgTypeDescription[msgCode])
+	}
+	return nil
+}

--- a/internal/driver/ttc/vector_bind_support_test.go
+++ b/internal/driver/ttc/vector_bind_support_test.go
@@ -10,6 +10,10 @@ import (
 // Named VECTOR types must bypass database/sql's default conversion so their
 // concrete type reaches the encoder registry unchanged.
 func TestCheckVectorNamedValue(t *testing.T) {
+	if err := checkVectorNamedValue(nil); err != driver.ErrSkip {
+		t.Fatalf("nil NamedValue: got %v want driver.ErrSkip", err)
+	}
+
 	cases := []struct {
 		name  string
 		value any

--- a/internal/driver/ttc/vector_bind_support_test.go
+++ b/internal/driver/ttc/vector_bind_support_test.go
@@ -1,0 +1,36 @@
+package ttc
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+)
+
+// Named VECTOR types must bypass database/sql's default conversion so their
+// concrete type reaches the encoder registry unchanged.
+func TestCheckVectorNamedValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		ok    bool
+	}{
+		{"float64", driverCommon.VectorFloat64{1, 2}, true},
+		{"float32", driverCommon.VectorFloat32{1, 2}, true},
+		{"int8", driverCommon.VectorInt8{1, 2}, true},
+		{"binary", driverCommon.VectorBinary{0xAA}, true},
+		{"plain float64", []float64{1, 2}, false},
+		{"raw bytes", []byte{1}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkVectorNamedValue(&driver.NamedValue{Ordinal: 1, Value: tc.value})
+			if tc.ok && err != nil {
+				t.Fatalf("expected accepted VECTOR type, got %v", err)
+			}
+			if !tc.ok && err != driver.ErrSkip {
+				t.Fatalf("expected driver.ErrSkip, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/driver/ttc/vector_locator.go
+++ b/internal/driver/ttc/vector_locator.go
@@ -1,0 +1,41 @@
+package ttc
+
+import driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+
+// buildVectorQuasiLocator builds a value-based LOB locator for VECTOR bind payloads.
+func buildVectorQuasiLocator(payloadLength int) driverCommon.B1Array {
+	locatorSize := kolblTempLocatorMaxLength
+	locator := make(driverCommon.B1Array, locatorSize)
+
+	length := locatorSize - kolbLocatorLengthHeaderBytes
+	locator[kolbLocatorLengthOffset] = byte(length >> 8)
+	locator[kolbLocatorLengthOffset+1] = byte(length)
+
+	locator[kolbVersionOffset] = 0
+	locator[kolbVersionOffset+1] = quasiLocatorVersion
+
+	locator[koll1FlagOffset] = (kolblBlobFlag | kolblValueBasedLocatorFlag) | kolblAbstractLocatorFlag
+	locator[koll2FlagOffset] = kolblInitializedFlag
+	locator[koll3FlagOffset] = 0
+	locator[koll4FlagOffset] = 0
+
+	// Byte width (BYTL) for binary payloads.
+	locator[8] = 0
+	locator[9] = 1
+
+	lobLen := driverCommon.UB8(payloadLength)
+	locator[10] = byte(lobLen >> 56)
+	locator[11] = byte(lobLen >> 48)
+	locator[12] = byte(lobLen >> 40)
+	locator[13] = byte(lobLen >> 32)
+	locator[14] = byte(lobLen >> 24)
+	locator[15] = byte(lobLen >> 16)
+	locator[16] = byte(lobLen >> 8)
+	locator[17] = byte(lobLen)
+
+	// Character set id remains zero for binary locators.
+	locator[20] = 0
+	locator[21] = 0
+
+	return locator
+}

--- a/internal/driver/ttc/vector_rxd.go
+++ b/internal/driver/ttc/vector_rxd.go
@@ -1,0 +1,50 @@
+package ttc
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/oracle/go-oracledb/v26/internal/common"
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+)
+
+// _unmarshalVectorColumn reads the LOB-prefetch envelope used for VECTOR results.
+// The fixed VECTOR prefetch size covers every supported dense VECTOR, so a complete
+// envelope contains all vector bytes followed by a locator that is not retained.
+func (rxd *tTIrxd) _unmarshalVectorColumn(ctx context.Context, mar driverCommon.Marshaller, col int) error {
+	locatorLength, err := mar.UnmarshalUB4(ctx)
+	if err != nil {
+		return fmt.Errorf("ttc: failed to read vector locator length: %w", err)
+	}
+	if locatorLength == 0 {
+		rxd.row[col] = nil
+		return nil
+	}
+
+	totalLen, err := mar.UnmarshalUB8(ctx)
+	if err != nil {
+		return fmt.Errorf("ttc: failed to read vector prefetch length: %w", err)
+	}
+	if _, err = mar.UnmarshalUB4(ctx); err != nil {
+		return fmt.Errorf("ttc: failed to read vector prefetch chunk size: %w", err)
+	}
+
+	prefetchedData, _, err := mar.UnmarshalCLRColumnData(ctx)
+	if err != nil {
+		return fmt.Errorf("ttc: failed to read vector prefetched data: %w", err)
+	}
+	if _, _, err = mar.UnmarshalCLRColumnData(ctx); err != nil {
+		return fmt.Errorf("ttc: failed to read vector locator: %w", err)
+	}
+	if totalLen > driverCommon.UB8(math.MaxInt) {
+		return fmt.Errorf("ttc: vector length %d exceeds host capacity", totalLen)
+	}
+	if len(prefetchedData) != int(totalLen) {
+		return fmt.Errorf("ttc: incomplete vector prefetch: got %d bytes, expected %d", len(prefetchedData), totalLen)
+	}
+
+	rxd.row[col] = append(driverCommon.B1Array(nil), prefetchedData...)
+	common.Odl.Debug("VECTOR RXD: fully prefetched payload", "totalBytes", totalLen)
+	return nil
+}

--- a/internal/driver/ttc/vector_rxd_test.go
+++ b/internal/driver/ttc/vector_rxd_test.go
@@ -1,0 +1,41 @@
+package ttc
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+)
+
+func TestUnmarshalVectorColumn(t *testing.T) {
+	ctx := context.Background()
+	buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 256)
+	locator := driverCommon.B1Array(bytes.Repeat([]byte{0x5A}, 9))
+	prefetched := driverCommon.B1Array{1, 2, 3}
+	if err := writer.MarshalUB4(ctx, driverCommon.UB4(len(locator))); err != nil {
+		t.Fatalf("marshal locator length: %v", err)
+	}
+	if err := writer.MarshalUB8(ctx, driverCommon.UB8(len(prefetched))); err != nil {
+		t.Fatalf("marshal vector length: %v", err)
+	}
+	if err := writer.MarshalUB4(ctx, driverCommon.UB4(len(prefetched))); err != nil {
+		t.Fatalf("marshal prefetch chunk size: %v", err)
+	}
+	if err := writer.MarshalCLR(ctx, prefetched, 0, len(prefetched)); err != nil {
+		t.Fatalf("marshal prefetched data: %v", err)
+	}
+	if err := writer.MarshalCLR(ctx, locator, 0, len(locator)); err != nil {
+		t.Fatalf("marshal locator: %v", err)
+	}
+
+	rxd := newTTIrxd().(*tTIrxd)
+	rxd.row = make([]driverCommon.B1Array, 1)
+	reader := createMarshaller(buf.bytes[:buf.currentWritePosition], 0, 0)
+	if err := rxd._unmarshalVectorColumn(ctx, reader, 0); err != nil {
+		t.Fatalf("unmarshal vector column: %v", err)
+	}
+	if !bytes.Equal(rxd.row[0], prefetched) {
+		t.Fatalf("prefetched data mismatch: got %v want %v", rxd.row[0], prefetched)
+	}
+}

--- a/internal/driver/ttc/vector_ttc_test.go
+++ b/internal/driver/ttc/vector_ttc_test.go
@@ -1,0 +1,277 @@
+package ttc
+
+import (
+	"bytes"
+	"context"
+	"database/sql/driver"
+	"errors"
+	"reflect"
+	"testing"
+
+	driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+	"github.com/oracle/go-oracledb/v26/internal/driver/ttc/converters"
+)
+
+func TestPrepareBindsAndOAC_VectorBinds(t *testing.T) {
+	args := []driver.Value{
+		driverCommon.VectorFloat64{1.25, -2.5},
+		driverCommon.VectorFloat32{3.5, 4.25},
+		driverCommon.VectorInt8{1, -2, 3},
+		driverCommon.VectorBinary{0xAA, 0x0F},
+	}
+
+	shelf := newShelf[driverCommon.MessageType]()
+	shelf.RegisterCodecFactory(NewCodecFactoryForProtocol(20))
+	sp := &statementProcessor{shelf: shelf}
+	if err := sp.prepareBindsAndOAC(args); err != nil {
+		t.Fatalf("prepareBindsAndOAC: %v", err)
+	}
+	row := sp.encodedValues[0]
+	if len(row) != len(args) || len(sp.currentOacs) != len(args) {
+		t.Fatalf("unexpected bind/OAC counts: %d/%d", len(row), len(sp.currentOacs))
+	}
+	for i, bind := range row {
+		if _, ok := bind.transport.(*vectorBindTransport); !ok {
+			t.Fatalf("bind %d transport=%T, want *vectorBindTransport", i, bind.transport)
+		}
+		if bind.isNull || len(bind.payload) == 0 {
+			t.Fatalf("bind %d unexpectedly empty", i)
+		}
+		if got := sp.currentOacs[i].(*tTIoac).dataType; got != driverCommon.UB1(DtyVec) {
+			t.Fatalf("OAC %d datatype=%d, want %d", i, got, DtyVec)
+		}
+	}
+}
+
+func TestTTIrxdMarshalToVectorLocator(t *testing.T) {
+	payload := driverCommon.B1Array{0xAA, 0xBB, 0xCC}
+	bind, err := buildVectorBindValue(normalizedBindValue{}, payload)
+	if err != nil {
+		t.Fatalf("build vector bind: %v", err)
+	}
+	rxd := newTTIrxd().(*tTIrxd)
+	rxd.setBindValues([]bindValue{bind})
+
+	buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 128)
+	if err := rxd.MarshalTo(context.Background(), writer); err != nil {
+		t.Fatalf("MarshalTo: %v", err)
+	}
+	reader := createMarshaller(buf.bytes[:buf.currentWritePosition], 0, 0)
+	locatorLen, err := reader.UnmarshalUB4(context.Background())
+	if err != nil {
+		t.Fatalf("read locator length: %v", err)
+	}
+	transport := bind.transport.(*vectorBindTransport)
+	if int(locatorLen) != len(transport.locator) {
+		t.Fatalf("locator length=%d, want %d", locatorLen, len(transport.locator))
+	}
+	locator, _, err := reader.UnmarshalCLRColumnData(context.Background())
+	if err != nil || !bytes.Equal(locator, transport.locator) {
+		t.Fatalf("locator mismatch: %v, err=%v", locator, err)
+	}
+	value, _, err := reader.UnmarshalCLRColumnData(context.Background())
+	if err != nil || !bytes.Equal(value, payload) {
+		t.Fatalf("payload mismatch: %v, err=%v", value, err)
+	}
+}
+
+func TestVectorBindTransportNullAndErrors(t *testing.T) {
+	ctx := context.Background()
+	nullBind, err := buildVectorBindValue(normalizedBindValue{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 16)
+	if err := nullBind.marshal(ctx, writer, TTIRXD, 0); err != nil {
+		t.Fatalf("marshal null vector: %v", err)
+	}
+	if got := buf.bytes[:buf.currentWritePosition]; !bytes.Equal(got, []byte{0}) {
+		t.Fatalf("null vector wire=%v", got)
+	}
+	if err := nullBind.marshal(ctx, failUB4Marshaller{writer}, TTIRXD, 0); err == nil {
+		t.Fatal("expected null-vector marshal error")
+	}
+
+	bind, err := buildVectorBindValue(normalizedBindValue{}, driverCommon.B1Array{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name  string
+		fail  FailOn
+		count int
+	}{
+		{"locator length", failOnWriteBytes, 1},
+		{"locator CLR", failOnWriteByte, 1},
+		{"payload CLR", failOnWriteByte, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mar := createMarshaller(make([]byte, 128), tc.fail, tc.count)
+			if err := bind.marshal(ctx, mar, TTIRXD, 0); err == nil {
+				t.Fatal("expected marshal error")
+			}
+		})
+	}
+}
+
+func TestBindValueUsesCLRTransportByDefault(t *testing.T) {
+	bind := bindValue{payload: driverCommon.B1Array{0x42}}
+	buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 16)
+	if err := bind.marshal(context.Background(), writer, TTIRXD, 0); err != nil {
+		t.Fatalf("default CLR marshal: %v", err)
+	}
+	if got := buf.bytes[:buf.currentWritePosition]; !bytes.Equal(got, []byte{1, 0x42}) {
+		t.Fatalf("default CLR wire=%v", got)
+	}
+}
+
+func TestVectorRXDErrorAndNullCases(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name  string
+		write func(driverCommon.Marshaller) error
+	}{
+		{"null", func(m driverCommon.Marshaller) error { return m.MarshalUB4(ctx, 0) }},
+		{"missing total length", func(m driverCommon.Marshaller) error { return m.MarshalUB4(ctx, 1) }},
+		{"missing prefetch size", func(m driverCommon.Marshaller) error {
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			return m.MarshalUB8(ctx, 1)
+		}},
+		{"missing prefetch data", func(m driverCommon.Marshaller) error {
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			if err := m.MarshalUB8(ctx, 1); err != nil {
+				return err
+			}
+			return m.MarshalUB4(ctx, 1)
+		}},
+		{"missing locator", func(m driverCommon.Marshaller) error {
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			if err := m.MarshalUB8(ctx, 1); err != nil {
+				return err
+			}
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			return m.MarshalCLR(ctx, driverCommon.B1Array{1}, 0, 1)
+		}},
+		{"incomplete prefetch", func(m driverCommon.Marshaller) error {
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			if err := m.MarshalUB8(ctx, 2); err != nil {
+				return err
+			}
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			if err := m.MarshalCLR(ctx, driverCommon.B1Array{1}, 0, 1); err != nil {
+				return err
+			}
+			return m.MarshalCLR(ctx, driverCommon.B1Array{}, 0, 0)
+		}},
+		{"host overflow", func(m driverCommon.Marshaller) error {
+			if err := m.MarshalUB4(ctx, 1); err != nil {
+				return err
+			}
+			if err := m.MarshalUB8(ctx, ^driverCommon.UB8(0)); err != nil {
+				return err
+			}
+			if err := m.MarshalUB4(ctx, 0); err != nil {
+				return err
+			}
+			if err := m.MarshalCLR(ctx, driverCommon.B1Array{}, 0, 0); err != nil {
+				return err
+			}
+			return m.MarshalCLR(ctx, driverCommon.B1Array{}, 0, 0)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 32)
+			if err := tc.write(writer); err != nil {
+				t.Fatal(err)
+			}
+			rxd := newTTIrxd().(*tTIrxd)
+			rxd.row = make([]driverCommon.B1Array, 1)
+			err := rxd._unmarshalVectorColumn(ctx, createMarshaller(buf.bytes[:buf.currentWritePosition], 0, 0), 0)
+			if tc.name == "null" {
+				if err != nil || rxd.row[0] != nil {
+					t.Fatalf("null vector: row=%v err=%v", rxd.row[0], err)
+				}
+			} else if err == nil {
+				t.Fatal("expected unmarshal error")
+			}
+		})
+	}
+}
+
+func TestUnmarshalColumnDispatchesVector(t *testing.T) {
+	ctx := context.Background()
+	buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 64)
+	for _, value := range []driverCommon.UB4{1} {
+		if err := writer.MarshalUB4(ctx, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.MarshalUB8(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.MarshalUB4(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.MarshalCLR(ctx, driverCommon.B1Array{7}, 0, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.MarshalCLR(ctx, driverCommon.B1Array{}, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	rxd := newTTIrxd().(*tTIrxd)
+	rxd.row = make([]driverCommon.B1Array, 1)
+	if err := rxd._unmarshalColumn(ctx, DtyVec, createMarshaller(buf.bytes[:buf.currentWritePosition], 0, 0), 0); err != nil {
+		t.Fatalf("VECTOR dispatch: %v", err)
+	}
+	if !bytes.Equal(rxd.row[0], []byte{7}) || len(rxd.lobColContext) != 1 {
+		t.Fatalf("VECTOR dispatch state: row=%v lobContexts=%d", rxd.row, len(rxd.lobColContext))
+	}
+}
+
+func TestCheckNamedValueAcceptsVector(t *testing.T) {
+	if err := checkNamedValue(&driver.NamedValue{Ordinal: 1, Value: driverCommon.VectorFloat64{1}}); err != nil {
+		t.Fatalf("VECTOR bind was rejected: %v", err)
+	}
+	if err := checkNamedValue(&driver.NamedValue{Ordinal: 1, Value: "ordinary"}); err != driver.ErrSkip {
+		t.Fatalf("ordinary bind error=%v, want ErrSkip", err)
+	}
+}
+
+func TestDecodeVectorColumnAndDefine(t *testing.T) {
+	payload, err := converters.EncodeVectorFloat32(driverCommon.VectorFloat32{1.5, -2.5})
+	if err != nil {
+		t.Fatalf("encode vector: %v", err)
+	}
+	value, err := DecodeVectorColumn(columnContext{}, payload)
+	if err != nil {
+		t.Fatalf("decode vector column: %v", err)
+	}
+	if got := value.([]float32); !reflect.DeepEqual(got, []float32{1.5, -2.5}) {
+		t.Fatalf("decoded vector=%v", got)
+	}
+	oac := newTTIOacVectorDefine(columnContext{}, 1).(*tTIoac)
+	if oac.dataType != driverCommon.UB1(DtyVec) || oac.codepointLengthLimit != vectorPrefetchSize {
+		t.Fatalf("VECTOR define OAC=%+v", oac)
+	}
+	if _, err := DecodeVectorColumn(columnContext{}, driverCommon.B1Array{0}); err == nil {
+		t.Fatal("expected wrapped VECTOR decode error")
+	}
+}
+
+type failUB4Marshaller struct{ driverCommon.Marshaller }
+
+func (failUB4Marshaller) MarshalUB4(context.Context, driverCommon.UB4) error {
+	return errors.New("forced UB4 failure")
+}

--- a/internal/driver/ttc/vector_ttc_test.go
+++ b/internal/driver/ttc/vector_ttc_test.go
@@ -31,10 +31,10 @@ func TestPrepareBindsAndOAC_VectorBinds(t *testing.T) {
 		t.Fatalf("unexpected bind/OAC counts: %d/%d", len(row), len(sp.currentOacs))
 	}
 	for i, bind := range row {
-		if _, ok := bind.transport.(*vectorBindTransport); !ok {
-			t.Fatalf("bind %d transport=%T, want *vectorBindTransport", i, bind.transport)
+		if bind.kind != bindValueKindVector {
+			t.Fatalf("bind %d kind=%d, want vector", i, bind.kind)
 		}
-		if bind.isNull || len(bind.payload) == 0 {
+		if bind.payload == nil || len(bind.payload) == 0 {
 			t.Fatalf("bind %d unexpectedly empty", i)
 		}
 		if got := sp.currentOacs[i].(*tTIoac).dataType; got != driverCommon.UB1(DtyVec) {
@@ -45,10 +45,7 @@ func TestPrepareBindsAndOAC_VectorBinds(t *testing.T) {
 
 func TestTTIrxdMarshalToVectorLocator(t *testing.T) {
 	payload := driverCommon.B1Array{0xAA, 0xBB, 0xCC}
-	bind, err := buildVectorBindValue(normalizedBindValue{}, payload)
-	if err != nil {
-		t.Fatalf("build vector bind: %v", err)
-	}
+	bind := newVectorBindValue(payload)
 	rxd := newTTIrxd().(*tTIrxd)
 	rxd.setBindValues([]bindValue{bind})
 
@@ -61,12 +58,12 @@ func TestTTIrxdMarshalToVectorLocator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read locator length: %v", err)
 	}
-	transport := bind.transport.(*vectorBindTransport)
-	if int(locatorLen) != len(transport.locator) {
-		t.Fatalf("locator length=%d, want %d", locatorLen, len(transport.locator))
+	wantLocator := buildVectorQuasiLocator(len(payload))
+	if int(locatorLen) != len(wantLocator) {
+		t.Fatalf("locator length=%d, want %d", locatorLen, len(wantLocator))
 	}
 	locator, _, err := reader.UnmarshalCLRColumnData(context.Background())
-	if err != nil || !bytes.Equal(locator, transport.locator) {
+	if err != nil || !bytes.Equal(locator, wantLocator) {
 		t.Fatalf("locator mismatch: %v, err=%v", locator, err)
 	}
 	value, _, err := reader.UnmarshalCLRColumnData(context.Background())
@@ -77,10 +74,7 @@ func TestTTIrxdMarshalToVectorLocator(t *testing.T) {
 
 func TestVectorBindTransportNullAndErrors(t *testing.T) {
 	ctx := context.Background()
-	nullBind, err := buildVectorBindValue(normalizedBindValue{}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	nullBind := newVectorBindValue(nil)
 	buf, writer := NewMarshalEngineTest(driverCommon.BIG_ENDIAN, B2, Universal, 16)
 	if err := nullBind.marshal(ctx, writer, TTIRXD, 0); err != nil {
 		t.Fatalf("marshal null vector: %v", err)
@@ -92,10 +86,7 @@ func TestVectorBindTransportNullAndErrors(t *testing.T) {
 		t.Fatal("expected null-vector marshal error")
 	}
 
-	bind, err := buildVectorBindValue(normalizedBindValue{}, driverCommon.B1Array{1})
-	if err != nil {
-		t.Fatal(err)
-	}
+	bind := newVectorBindValue(driverCommon.B1Array{1})
 	for _, tc := range []struct {
 		name  string
 		fail  FailOn

--- a/oracle/OracleDriver_VECTOR_test.go
+++ b/oracle/OracleDriver_VECTOR_test.go
@@ -13,7 +13,7 @@ func TestDriver_Vector_Basic(t *testing.T) {
 	if TestingConfig == nil {
 		t.Skip("No configuration available")
 	}
-	if TestingConfig.DatabaseVersion < 23 {
+	if TestingConfig.DatabaseVersion.Major < 23 {
 		t.Skip("VECTOR datatype requires Oracle Database 23c+")
 	}
 

--- a/oracle/OracleDriver_VECTOR_test.go
+++ b/oracle/OracleDriver_VECTOR_test.go
@@ -1,0 +1,99 @@
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// TestDriver_Vector_Basic verifies INSERT, SELECT, UPDATE, and DELETE for all
+// dense VECTOR element types supported by the driver.
+func TestDriver_Vector_Basic(t *testing.T) {
+	if TestingConfig == nil {
+		t.Skip("No configuration available")
+	}
+	if TestingConfig.DatabaseVersion < 23 {
+		t.Skip("VECTOR datatype requires Oracle Database 23c+")
+	}
+
+	ctx := context.Background()
+	const dimensions = 1024
+	values := make(VectorFloat64, dimensions)
+	updatedValues := make(VectorFloat64, dimensions)
+	for i := range values {
+		values[i] = float64(i) / 4
+		updatedValues[i] = -float64(i) / 8
+	}
+
+	tests := []struct {
+		name        string
+		table       string
+		definition  string
+		insert      any
+		want        any
+		update      any
+		updatedWant any
+	}{
+		{"float64", "vector_f64", "VECTOR(1024, FLOAT64)", values, []float64(values), updatedValues, []float64(updatedValues)},
+		{"float32", "vector_f32", "VECTOR(3, FLOAT32)", VectorFloat32{4.5, -5.25, 6.75}, []float32{4.5, -5.25, 6.75}, VectorFloat32{-1.5, 2.25, 9.75}, []float32{-1.5, 2.25, 9.75}},
+		{"int8", "vector_i8", "VECTOR(3, INT8)", VectorInt8{1, -2, 3}, []int8{1, -2, 3}, VectorInt8{-8, 0, 7}, []int8{-8, 0, 7}},
+		{"binary", "vector_binary", "VECTOR(16, BINARY)", VectorBinary{0xAA, 0x0F}, []byte{0xAA, 0x0F}, VectorBinary{0x55, 0xF0}, []byte{0x55, 0xF0}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := openTestDBWithConfig(TestingConfig)
+			if err != nil {
+				t.Fatalf("open test database: %v", err)
+			}
+			defer db.Close()
+
+			_ = dropTable(ctx, db, tc.table)
+			if err := createTable(ctx, db, tc.table, map[string]string{"id": "NUMBER PRIMARY KEY", "vec": tc.definition}); err != nil {
+				t.Fatalf("create table: %v", err)
+			}
+			defer func() { _ = dropTable(ctx, db, tc.table) }()
+
+			if result, err := db.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id, vec) VALUES (:1, :2)", tc.table), 1, tc.insert); err != nil {
+				t.Fatalf("insert: %v", err)
+			} else if count, err := result.RowsAffected(); err != nil || count != 1 {
+				t.Fatalf("insert rows affected: got %d, err=%v", count, err)
+			}
+
+			assertVector := func(want any) {
+				var got any
+				switch want.(type) {
+				case []float64:
+					got = new([]float64)
+				case []float32:
+					got = new([]float32)
+				case []int8:
+					got = new([]int8)
+				case []byte:
+					got = new([]byte)
+				}
+				if err := db.QueryRowContext(ctx, fmt.Sprintf("SELECT vec FROM %s WHERE id = :1", tc.table), 1).Scan(got); err != nil {
+					t.Fatalf("fetch: %v", err)
+				}
+				if !reflect.DeepEqual(reflect.ValueOf(got).Elem().Interface(), want) {
+					t.Fatalf("vector mismatch: got %v want %v", reflect.ValueOf(got).Elem().Interface(), want)
+				}
+			}
+			assertVector(tc.want)
+
+			if result, err := db.ExecContext(ctx, fmt.Sprintf("UPDATE %s SET vec = :1 WHERE id = :2", tc.table), tc.update, 1); err != nil {
+				t.Fatalf("update: %v", err)
+			} else if count, err := result.RowsAffected(); err != nil || count != 1 {
+				t.Fatalf("update rows affected: got %d, err=%v", count, err)
+			}
+			assertVector(tc.updatedWant)
+
+			if result, err := db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = :1", tc.table), 1); err != nil {
+				t.Fatalf("delete: %v", err)
+			} else if count, err := result.RowsAffected(); err != nil || count != 1 {
+				t.Fatalf("delete rows affected: got %d, err=%v", count, err)
+			}
+		})
+	}
+}

--- a/oracle/vector_types.go
+++ b/oracle/vector_types.go
@@ -1,0 +1,20 @@
+package oracle
+
+import driverCommon "github.com/oracle/go-oracledb/v26/internal/driver/common"
+
+// VectorFloat64 is an alias for dense VECTOR(FLOAT64) bind values.
+// VECTOR query results are decoded as []float64.
+type VectorFloat64 = driverCommon.VectorFloat64
+
+// VectorFloat32 is an alias for dense VECTOR(FLOAT32) bind values.
+// VECTOR query results are decoded as []float32.
+type VectorFloat32 = driverCommon.VectorFloat32
+
+// VectorInt8 is an alias for dense VECTOR(INT8) bind values.
+// VECTOR query results are decoded as []int8.
+type VectorInt8 = driverCommon.VectorInt8
+
+// VectorBinary is an alias for packed BINARY VECTOR bind values.
+// Each byte stores 8 dimensions in MSB-first order.
+// VECTOR query results are decoded as []byte using the same packed layout.
+type VectorBinary = driverCommon.VectorBinary


### PR DESCRIPTION
# Description

Adds native dense VECTOR support for Oracle Database 23ai and later.

Applications can bind `oracle.VectorFloat64`, `oracle.VectorFloat32`,
`oracle.VectorInt8`, and `oracle.VectorBinary` values in DML statements.
Fetched VECTOR values are decoded as `[]float64`, `[]float32`, `[]int8`, or
packed `[]byte` for BINARY vectors.

This adds VECTOR codecs, `DtyVec` bind and define metadata, VECTOR bind
marshalling with its required quasi-locator, and a fixed define prefetch size
that covers the largest dense FLOAT64 VECTOR envelope. The README documents
the public VECTOR bind types and fetch mappings.

No additional dependencies are required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests
  - `internal/driver/ttc/converters/vector_test.go`
  - `internal/driver/ttc/vector_ttc_test.go`
  - `internal/driver/ttc/vector_rxd_test.go`
  - `internal/driver/ttc/ttioac_test.go`
  - Full suite: `go test ./...`

- [x] VECTOR integration test
  - `oracle/OracleDriver_VECTOR_test.go`
  - `TestDriver_Vector_Basic` passed against a local Oracle Database Free 26ai
    container. It covers INSERT, SELECT, UPDATE, and DELETE for FLOAT64,
    FLOAT32, INT8, and BINARY VECTOR values.

**Test Configuration**:

- Database: Oracle Database Free 26ai
- Platform: macOS on Apple Silicon
- Toolchain: Go 1.26.6
- SDK: Not applicable

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules