### PR TITLE
Add client identifier (CID) to Oracle Net CONNECT_DATA

### DIFF
--- a/internal/common/pkg_init.go
+++ b/internal/common/pkg_init.go
@@ -1,7 +1,49 @@
 package common
 
-// init loads the dictionary of error messages
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+var (
+	// ProgramName is the executable base name captured during package initialization.
+	ProgramName string
+	// HostName is the local hostname captured during package initialization.
+	HostName string
+	// UserName is the operating-system username captured during package initialization.
+	UserName string
+	// ProcessID is the current process ID captured during package initialization.
+	ProcessID string
+)
+
+// initSystemInformation captures process metadata once in the common layer so
+// driver components avoid repeating operating-system calls.
+func initSystemInformation() {
+	ProgramName = "unknown"
+	if executable, err := os.Executable(); err == nil {
+		if name := filepath.Base(executable); name != "" {
+			ProgramName = name
+		}
+	}
+
+	HostName = "unknown"
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		HostName = hostname
+	}
+
+	UserName = "oraclegoclient"
+	if currentUser, err := user.Current(); err == nil && currentUser.Username != "" {
+		UserName = currentUser.Username
+	}
+
+	ProcessID = strconv.Itoa(os.Getpid())
+}
+
+// init initializes shared system information and error-message dictionaries.
 func init() {
+	initSystemInformation()
 	initMessagesEn()
 	initMessagesFr()
 }

--- a/internal/driver/network/session/nsprotocol.go
+++ b/internal/driver/network/session/nsprotocol.go
@@ -45,6 +45,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/oracle/go-oracledb/v26/internal/common"
@@ -77,6 +78,30 @@ type networkSession struct {
 	sndBuf              []byte
 	pendingPacket       []byte // to store pushed back packet from CheckinbandNotification
 	resetInProgress     bool
+}
+
+// cidSanitizer prevents OS-provided CID values from changing the naming structure.
+var cidSanitizer = strings.NewReplacer("(", "_", ")", "_", "=", "_")
+
+// sanitizeCIDValue returns a value that is safe to serialize in a naming node.
+func sanitizeCIDValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "unknown"
+	}
+	return cidSanitizer.Replace(v)
+}
+
+// buildCIDNode creates the Oracle Net client identifier nested under CONNECT_DATA.
+func buildCIDNode() naming.Node {
+	return naming.Node{
+		Name: "CID",
+		Children: []naming.Node{
+			{Name: "PROGRAM", Value: sanitizeCIDValue(common.ProgramName)},
+			{Name: "HOST", Value: sanitizeCIDValue(common.HostName)},
+			{Name: "USER", Value: sanitizeCIDValue(common.UserName)},
+		},
+	}
 }
 
 const (
@@ -489,9 +514,10 @@ func ConnectToOptionWithConnectionID(ctx context.Context, option *naming.Connect
 	}
 	connectData, err := root.GetNode("DESCRIPTION/CONNECT_DATA")
 	if err != nil {
-		connectData = &naming.Node{Name: "CONNECT_DATA"}
-		root.Children = append(root.Children, *connectData)
+		root.Children = append(root.Children, naming.Node{Name: "CONNECT_DATA"})
+		connectData = &root.Children[len(root.Children)-1]
 	}
+	connectData.Children = append(connectData.Children, buildCIDNode())
 	connIDNode := naming.Node{Name: "CONNECTION_ID", Value: ns.sAtts.nt.Connectionid}
 	connectData.Children = append(connectData.Children, connIDNode)
 	newConnectStr := root.ToString()

--- a/internal/driver/network/session/nsprotocol_test.go
+++ b/internal/driver/network/session/nsprotocol_test.go
@@ -341,6 +341,36 @@ func TestConnectToOption(t *testing.T) {
 	})
 }
 
+func TestCIDNode(t *testing.T) {
+	originalProgramName, originalHostName, originalUserName := common.ProgramName, common.HostName, common.UserName
+	t.Cleanup(func() {
+		common.ProgramName, common.HostName, common.UserName = originalProgramName, originalHostName, originalUserName
+	})
+	common.ProgramName = " program(name)=value "
+	common.HostName = " host(name)=value "
+	common.UserName = " user(name)=value "
+
+	cid := buildCIDNode()
+	if got, want := cid.ToString(), "(CID=(PROGRAM=program_name__value)(HOST=host_name__value)(USER=user_name__value))"; got != want {
+		t.Fatalf("CID: got %s, want %s", got, want)
+	}
+}
+
+func TestSanitizeCIDValue(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  string
+	}{
+		{value: "", want: "unknown"},
+		{value: " \t ", want: "unknown"},
+		{value: " (a=b) ", want: "_a_b_"},
+	} {
+		if got := sanitizeCIDValue(test.value); got != test.want {
+			t.Errorf("sanitizeCIDValue(%q): got %q, want %q", test.value, got, test.want)
+		}
+	}
+}
+
 // TestConnectSubtests groups subtests for ConnectToOption
 func TestConnectSubtests(t *testing.T) {
 	t.Parallel()

--- a/internal/driver/ttc/pkg_init.go
+++ b/internal/driver/ttc/pkg_init.go
@@ -40,10 +40,6 @@ package ttc
 
 import (
 	"container/list"
-	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"time"
@@ -84,28 +80,11 @@ func _initEnvironmentStaticInformation() {
 	// To be consistent with other drivers like JDBC-thin that add their version:
 	currentDriverName = driverCommon.StringToB1Array(driverNameDefault + " : " + common.DriverVersion)
 
-	if u, err := user.Current(); err == nil {
-		currentUserName = driverCommon.StringToB1Array(u.Username)
-	} else {
-		common.Odl.Info(fmt.Sprintf("using default as user name"))
-		currentUserName = driverCommon.StringToB1Array("unknown")
-	}
-
-	if e, err := os.Executable(); err == nil {
-		currentProcessPath = driverCommon.StringToB1Array(filepath.Base(e))
-	} else {
-		common.Odl.Info(fmt.Sprintf("using default as process path"))
-		currentProcessPath = driverCommon.StringToB1Array("unknown")
-	}
-	var currentProcessId driverCommon.B1Array
-	currentProcessId = driverCommon.StringToB1Array(strconv.Itoa(os.Getpid()))
-	var currentMachineName driverCommon.B1Array
-	if h, err := os.Hostname(); err == nil {
-		currentMachineName = driverCommon.StringToB1Array(h)
-	} else {
-		common.Odl.Info(fmt.Sprintf("using default as machine name"))
-		currentMachineName = driverCommon.StringToB1Array("oraclegoclient")
-	}
+	// Reuse the process metadata captured once by common to avoid repeated OS calls.
+	currentUserName = driverCommon.StringToB1Array(common.UserName)
+	currentProcessPath = driverCommon.StringToB1Array(common.ProgramName)
+	currentProcessId := driverCommon.StringToB1Array(common.ProcessID)
+	currentMachineName := driverCommon.StringToB1Array(common.HostName)
 	currentDriverInternalName = driverCommon.StringToB1Array(driverInternalName)
 
 	_keyValStaticInfoForOsesskey.PushBack(&driverCommon.KeyValue{Key: driverCommon.StringToB1Array(authTerminal), Value: currentTerminal})


### PR DESCRIPTION
# Description

Adds a client identifier (CID) to Oracle Net CONNECT_DATA when creating an NSPTCN connection:
(CID=(PROGRAM=<executable>) (HOST=<hostname> ) (USER=<username>))
The CID is appended under CONNECT_DATA immediately before the existing
CONNECTION_ID node. If CONNECT_DATA is absent, it is created
under DESCRIPTION
OS-derived values are initialized once in internal/common and reused by both Oracle Net and TTC code, **avoiding repeated system calls.** CID values are trimmed and sanitized before serialization to prevent naming-string structure changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce them. Please also list any relevant details for your test configuration.

- [x] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
